### PR TITLE
Implement whitened representation of q(u)

### DIFF
--- a/demo/demo_coal_1d.py
+++ b/demo/demo_coal_1d.py
@@ -32,11 +32,14 @@ def build_model(events, domain, M=20):
     kernel = gpflow.kernels.SquaredExponential()
     Z = domain_grid(domain, M)
     feature = gpflow.inducing_variables.InducingPoints(Z)
+    gpflow.set_trainable(feature, False)
     q_mu = np.zeros(M)
     q_S = np.eye(M)
     num_events = len(events)
     beta0 = np.sqrt(num_events / domain_area(domain))
-    model = VBPP(feature, kernel, domain, q_mu, q_S, beta0=beta0, num_events=num_events)
+    model = VBPP(
+        feature, kernel, domain, q_mu, q_S, beta0=beta0, num_events=num_events, whiten=True
+    )
     return model
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -33,7 +33,7 @@ class Data:
 def test_initialization(whiten):
     kernel = SquaredExponential()
     feature = InducingPoints(Data.Z)
-    M = len(feature)
+    M = feature.num_inducing
     m_init = np.zeros(M)
     S_init = np.eye(M) if whiten else kernel(Data.Z, full_cov=True)
     m = VBPP(feature, kernel, Data.domain, m_init, S_init, whiten=whiten)
@@ -47,7 +47,7 @@ def test_whitening():
     kernel = SquaredExponential()
     feature = InducingPoints(Data.Z)
 
-    M = len(feature)
+    M = feature.num_inducing
     np.random.seed(42)
     m_init = np.random.randn(M)
     S_init = (lambda A: A @ A.T)(np.random.randn(M, M))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,7 +30,7 @@ class Data:
 
 
 @pytest.mark.parametrize("whiten", [True, False])
-def test_initialization(whiten):
+def test_elbo_terms_at_initialization(whiten):
     kernel = SquaredExponential()
     feature = InducingPoints(Data.Z)
     M = feature.num_inducing
@@ -43,7 +43,7 @@ def test_initialization(whiten):
     assert np.allclose(m._elbo_integral_term(Kuu).numpy(), -m.total_area)
 
 
-def test_whitening():
+def test_equivalence_of_whitening():
     kernel = SquaredExponential()
     feature = InducingPoints(Data.Z)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -70,3 +70,23 @@ def test_equivalence_of_whitening():
     np.testing.assert_allclose(
         m_whitened.elbo(Data.events), m_unwhitened.elbo(Data.events), rtol=1e-6
     )
+
+
+@pytest.mark.parametrize("whiten", [True, False])
+def test_lambda_predictions(whiten):
+    kernel = SquaredExponential()
+    feature = InducingPoints(Data.Z)
+
+    M = feature.num_inducing
+    np.random.seed(42)
+    m_init = np.random.randn(M)
+    S_init = (lambda A: A @ A.T)(np.random.randn(M, M))
+    beta0 = 1.234
+
+    m = VBPP(feature, kernel, Data.domain, m_init, S_init, whiten=whiten, beta0=beta0)
+
+    mean, lower, upper = m.predict_lambda_and_percentiles(X)
+    mean_again = m.predict_lambda(X)
+    np.testing.assert_allclose(mean, mean_again)
+    np.testing.assert_array_less(lower, mean)
+    np.testing.assert_array_less(mean, upper)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,6 +27,7 @@ class Data:
     domain = np.array([[0.0, 10.0]])
     events = rng.uniform(0, 10, size=20)[:, None]
     Z = np.linspace(0, 10, 17)[:, None]
+    Xtest = np.linspace(-2, 12, 37)[:, None]
 
 
 @pytest.mark.parametrize("whiten", [True, False])
@@ -85,8 +86,8 @@ def test_lambda_predictions(whiten):
 
     m = VBPP(feature, kernel, Data.domain, m_init, S_init, whiten=whiten, beta0=beta0)
 
-    mean, lower, upper = m.predict_lambda_and_percentiles(X)
-    mean_again = m.predict_lambda(X)
+    mean, lower, upper = m.predict_lambda_and_percentiles(Data.Xtest)
+    mean_again = m.predict_lambda(Data.Xtest)
     np.testing.assert_allclose(mean, mean_again)
     np.testing.assert_array_less(lower, mean)
     np.testing.assert_array_less(mean, upper)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2022 ST John
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from gpflow.inducing_variables import InducingPoints
+from gpflow.kernels import SquaredExponential
+import gpflow
+from vbpp import VBPP
+
+rng = np.random.RandomState(0)
+
+
+class Data:
+    domain = np.array([[0.0, 10.0]])
+    events = rng.uniform(0, 10, size=20)[:, None]
+    Z = np.linspace(0, 10, 17)[:, None]
+
+
+@pytest.mark.parametrize("whiten", [True, False])
+def test_initialization(whiten):
+    kernel = SquaredExponential()
+    feature = InducingPoints(Data.Z)
+    M = len(feature)
+    m_init = np.zeros(M)
+    S_init = np.eye(M) if whiten else kernel(Data.Z, full_cov=True)
+    m = VBPP(feature, kernel, Data.domain, m_init, S_init, whiten=whiten)
+
+    Kuu = m.compute_Kuu()
+    assert np.allclose(m.prior_kl(Kuu).numpy(), 0.0)
+    assert np.allclose(m._elbo_integral_term(Kuu).numpy(), -m.total_area)
+
+
+def test_whitening():
+    kernel = SquaredExponential()
+    feature = InducingPoints(Data.Z)
+
+    M = len(feature)
+    np.random.seed(42)
+    m_init = np.random.randn(M)
+    S_init = (lambda A: A @ A.T)(np.random.randn(M, M))
+
+    Kuu = kernel(Data.Z)
+    L = np.linalg.cholesky(Kuu.numpy())
+
+    beta0 = 1.234
+    m_whitened = VBPP(feature, kernel, Data.domain, m_init, S_init, whiten=True, beta0=beta0)
+    m_unwhitened = VBPP(
+        feature, kernel, Data.domain, L @ m_init, L @ S_init @ L.T, whiten=False, beta0=beta0
+    )
+
+    Xnew = np.linspace(-3, 13, 17)[:, None]
+    f_mean_whitened, f_var_whitened = m_whitened.predict_f(Xnew)
+    f_mean_unwhitened, f_var_unwhitened = m_unwhitened.predict_f(Xnew)
+    np.testing.assert_allclose(f_mean_whitened, f_mean_unwhitened, rtol=1e-3)
+    np.testing.assert_allclose(f_var_whitened, f_var_unwhitened, rtol=2e-3)
+
+    np.testing.assert_allclose(
+        m_whitened.elbo(Data.events), m_unwhitened.elbo(Data.events), rtol=1e-6
+    )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -24,7 +24,7 @@ rng = np.random.RandomState(0)
 
 
 @pytest.mark.parametrize("whiten", [True, False])
-def test_smoke(whiten):
+def test_smoke_optimize_and_predict(whiten):
     domain = np.array([[0.0, 10.0]])
     events = rng.uniform(0, 10, size=20)[:, None]
 
@@ -39,3 +39,12 @@ def test_smoke(whiten):
 
     opt = gpflow.optimizers.Scipy()
     opt.minimize(objective_closure, m.trainable_variables, options=dict(maxiter=2))
+
+    X = np.linspace(-1, 11, 19)[:, None]
+    mean, lower, upper = m.predict_lambda_and_percentiles(X)
+    mean_again = m.predict_lambda(X)
+    np.testing.assert_allclose(mean, mean_again)
+    np.testing.assert_array_less(lower, mean)
+    np.testing.assert_array_less(mean, upper)
+
+    _ = m.predict_f_samples(X)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -31,7 +31,7 @@ def test_smoke(whiten):
     kernel = SquaredExponential()
     Z = np.linspace(0, 10, 17)[:, None]
     feature = InducingPoints(Z)
-    M = len(feature)
+    M = feature.num_inducing
     m = VBPP(feature, kernel, domain, np.zeros(M), np.eye(M), whiten=whiten)
 
     def objective_closure():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (C) 2022 ST John
 # Copyright (C) Secondmind Ltd 2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import numpy as np
-import tensorflow as tf
 from gpflow.inducing_variables import InducingPoints
 from gpflow.kernels import SquaredExponential
 import gpflow
@@ -22,17 +23,16 @@ from vbpp import VBPP
 rng = np.random.RandomState(0)
 
 
-def test_smoke():
+@pytest.mark.parametrize("whiten", [True, False])
+def test_smoke(whiten):
     domain = np.array([[0.0, 10.0]])
-    kernel = SquaredExponential()
     events = rng.uniform(0, 10, size=20)[:, None]
-    feature = InducingPoints(np.linspace(0, 10, 20)[:, None])
-    M = len(feature)
-    m = VBPP(feature, kernel, domain, np.zeros(M), np.eye(M))
 
-    Kuu = m.compute_Kuu()
-    m.q_sqrt.assign(np.linalg.cholesky(Kuu))
-    assert np.allclose(m.prior_kl(tf.identity(Kuu)).numpy(), 0.0)
+    kernel = SquaredExponential()
+    Z = np.linspace(0, 10, 17)[:, None]
+    feature = InducingPoints(Z)
+    M = len(feature)
+    m = VBPP(feature, kernel, domain, np.zeros(M), np.eye(M), whiten=whiten)
 
     def objective_closure():
         return -m.elbo(events)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -41,10 +41,4 @@ def test_smoke_optimize_and_predict(whiten):
     opt.minimize(objective_closure, m.trainable_variables, options=dict(maxiter=2))
 
     X = np.linspace(-1, 11, 19)[:, None]
-    mean, lower, upper = m.predict_lambda_and_percentiles(X)
-    mean_again = m.predict_lambda(X)
-    np.testing.assert_allclose(mean, mean_again)
-    np.testing.assert_array_less(lower, mean)
-    np.testing.assert_array_less(mean, upper)
-
     _ = m.predict_f_samples(X)

--- a/vbpp/model.py
+++ b/vbpp/model.py
@@ -62,6 +62,11 @@ class VBPP(gpflow.models.GPModel, gpflow.models.ExternalDataTrainingLossMixin):
     Implementation of the "Variational Bayes for Point Processes" model by
     Lloyd et al. (2015), with capability for multiple observations and the
     constant offset `beta0` from John and Hensman (2018).
+
+    Note: If you encounter "Input matrix is not invertible." errors during
+    training, this may be due to inducing points moving too close to each
+    other, especially in 1D. You may want to consider fixing the inducing
+    points, e.g. on a grid.
     """
 
     def __init__(
@@ -102,6 +107,8 @@ class VBPP(gpflow.models.GPModel, gpflow.models.ExternalDataTrainingLossMixin):
 
         :param num_events: total number of events, defaults to events.shape[0]
             (relevant when feeding in minibatches)
+
+        :param whiten: whether to use the whitened representation of q(u).
         """
         super().__init__(
             kernel,

--- a/vbpp/model.py
+++ b/vbpp/model.py
@@ -1,3 +1,4 @@
+# Copyright (C) 2022 ST John
 # Copyright (C) Secondmind Ltd 2017-2020
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/vbpp/model.py
+++ b/vbpp/model.py
@@ -75,7 +75,7 @@ class VBPP(gpflow.models.GPModel, gpflow.models.ExternalDataTrainingLossMixin):
         beta0: float = 1e-6,
         num_observations: int = 1,
         num_events: Optional[int] = None,
-        whiten: bool = True,
+        whiten: bool = False,
     ):
         """
         D = number of dimensions

--- a/vbpp/model.py
+++ b/vbpp/model.py
@@ -109,6 +109,8 @@ class VBPP(gpflow.models.GPModel, gpflow.models.ExternalDataTrainingLossMixin):
             (relevant when feeding in minibatches)
 
         :param whiten: whether to use the whitened representation of q(u).
+            When whiten=True, we parametrise q(v) = N(q_mu, q_S) instead, and u = L v,
+            where L is the lower-triangular Cholesky factor of the kernel matrix Kuu.
         """
         super().__init__(
             kernel,

--- a/vbpp/model.py
+++ b/vbpp/model.py
@@ -153,11 +153,13 @@ class VBPP(gpflow.models.GPModel, gpflow.models.ExternalDataTrainingLossMixin):
     def total_area(self):
         return np.prod(self.domain[:, 1] - self.domain[:, 0])
 
-    def predict_f(self, Xnew, full_cov=False, *, Kuu=None):
+    def predict_f(self, Xnew, full_cov=False, *, full_output_cov=False, Kuu=None):
         """
         VBPP-specific conditional on the approximate posterior q(u), including a
         constant mean function.
         """
+        if full_output_cov:
+            raise NotImplementedError("only supports single-output models")
         mean, var = conditional(
             Xnew,
             self.inducing_variable,


### PR DESCRIPTION
- new feature: add `whiten` keyword argument to `VBPP` constructor with which the whitened representation of q(u) can be turned on.
- bugfix: add `full_output_cov` keyword argument to `predict_f` (though only `False` is implemented) so that the `predict_f_samples` method can be used
- improved tests